### PR TITLE
Add HTML escaping and truncate long names to 12 characters in ranking…

### DIFF
--- a/source/php/rank_print.php
+++ b/source/php/rank_print.php
@@ -1,13 +1,21 @@
-<?php
+<?php 
 $file = file("./../txt/ranking.txt");
 $type = key($_GET);
 foreach ($file as $f) {
     list($date, $name, $score) = explode(',', rtrim($f));
+    $name = htmlspecialchars($name, ENT_QUOTES, 'UTF-8');  // エスケープ処理
+    
+    // 名前を12文字でカットする処理
+    if (strlen($name) > 12) {
+        $name = substr($name, 0, 12) . '...';  // 12文字でカットし、末尾に「...」を追加
+    }
+
     $db[$date . ',' . $name] = $score;
 }
 arsort($db); //スコアが高い順にソートする
 foreach ($db as $key => $val) {
     list($date, $name) = explode(',', $key);
+    
     if ($type === "d") {
         $currentDate = date('y/m/d');
         $dateParts = explode(' ', $date);
@@ -21,7 +29,8 @@ foreach ($db as $key => $val) {
         if ($month == $currentDate) {
             echo "$key,$val\n";
         }
-    } else
+    } else {
         echo "$key,$val\n";
+    }
 }
 ?>

--- a/source/php/rank_write.php
+++ b/source/php/rank_write.php
@@ -1,7 +1,8 @@
-<?php
+<?php 
 if (isset($_GET['name']) && isset($_GET['score'])) {
+    $name = htmlspecialchars($_GET['name'], ENT_QUOTES, 'UTF-8');
     $fw = fopen("./../txt/ranking.txt", "a"); // 追記する 
-    fwrite($fw, date("y/m/d H:i:s") . "," . $_GET['name'] . "," . $_GET['score'] . "\n");
+    fwrite($fw, date("y/m/d H:i:s") . "," . $name . "," . $_GET['score'] . "\n");
     fclose($fw);
 }
 ?>


### PR DESCRIPTION
… systemThis commit introduces two key updates to the ranking system. 

1. HTML Escaping: 
   - To enhance security and prevent potential issues with HTML rendering, all player names are now processed with HTML escaping using the htmlspecialchars function. This ensures that any special characters in the names do not interfere with the page layout or introduce security vulnerabilities.

2. Name Truncation:
   - To maintain a clean and consistent display of player names in the rankings, names that exceed 12 characters will be truncated. The truncated names will be followed by an ellipsis ("...") to indicate that the name has been shortened. This improves the readability of the ranking list and prevents layout distortion caused by excessively long names.

These changes aim to enhance user experience and ensure the robustness of the ranking system.
